### PR TITLE
refactor using symbolTable for preAlloc variables

### DIFF
--- a/src/codeGeneration/codeGeneration.h
+++ b/src/codeGeneration/codeGeneration.h
@@ -7,6 +7,7 @@
 #include <stdio.h>
 
 #include "symbolTable.h"
+#include "typeChecker.h"
 
 /**
  * @brief String literal entry in the global string table.
@@ -61,9 +62,9 @@ typedef struct StackContext {
  * following x86-64 conventions for efficient memory access.
  */
 typedef enum {
-    STACK_SIZE_INT = 8,
-    STACK_SIZE_FLOAT = 8,
-    STACK_SIZE_BOOL = 8,
+    STACK_SIZE_INT = 4,
+    STACK_SIZE_FLOAT = 4,
+    STACK_SIZE_BOOL = 1,
     STACK_SIZE_STRING = 8
 } StackSize;
 
@@ -158,5 +159,8 @@ int generateLoop(ASTNode node, StackContext context);
 
 DataType getOperandType(ASTNode node, StackContext context);
 
+StackContext createCodeGenContextSymb(const char * file, SymbolTable globalSymbolTable);
+
+int generateCodeWithSymbolTable(ASTNode ast, const char *outputFile);
 
 #endif //CINTERPRETER_CODEGENERATION_H

--- a/src/main.c
+++ b/src/main.c
@@ -70,7 +70,7 @@ void printTokenList(Token t) {
 
 int main() {
     printf("=== LEXER TEST ===\n");
-    char *input = "int x = 10; int y = 15; x < y ? x++ : y++;";
+    char *input = "int x = 10; int y = 15; x < y ? {int b = 22; x++;} : y++;";
     printf("Input:\n%s\n\n", input);
 
     // Use the new two-step lexer process
@@ -114,7 +114,7 @@ int main() {
     if (parseSuccess && typeCheckSuccess) {
         printf("   Generating assembly code...\n");
         const char *outputFile = "../output.s";
-        codeGenSuccess = generateCode(ast, outputFile);
+        codeGenSuccess = generateCodeWithSymbolTable(ast, outputFile);
 
         if (codeGenSuccess) {
             printf("   Code generation PASSED\n");


### PR DESCRIPTION
# WIP:
 bcs symbol table uses LIFO structure and context is freed after type-checker life cycle ends it doesnt know his children which is needed to find variables in deeper scopes, refactor will be done