### PR TITLE
ref: tech debt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -O3")
 
 # Source files (excluding main.c for library)
 set(LIB_SOURCES
+        src/codeGeneration/constants.h
         src/lexer/lexer.c
         src/parser/parser.c
         src/errorHandling/errorHandling.c

--- a/src/codeGeneration/codeGenExpressions.c
+++ b/src/codeGeneration/codeGenExpressions.c
@@ -8,6 +8,7 @@
 #include "builtIns.h"
 #include "codeGenOperations.h"
 #include "registerHandling.h"
+#include "constants.h"
 
 #include <stdlib.h>
 
@@ -120,10 +121,10 @@ RegisterId generateExpressionToRegister(ASTNode node, StackContext context,
     }
     leftReg = generateExpressionToRegister(left, context, leftReg);
     if (needSpill) {
-      spillRegisterToTempVar(context, leftReg, operandType, TEMP_VAR_A);
+      spillRegisterToTempVar(context, leftReg, operandType, TEMP_VAR_A_OFFSET);
       rightReg = generateExpressionToRegister(right, context, REG_RAX);
       leftReg = getOppositeBranchRegister(rightReg);
-      restoreRegisterFromTempVar(context, leftReg, operandType, TEMP_VAR_A);
+      restoreRegisterFromTempVar(context, leftReg, operandType, TEMP_VAR_A_OFFSET);
     } else {
       rightReg = generateExpressionToRegister(right, context, rightReg);
     }
@@ -332,7 +333,7 @@ int generateConditional(ASTNode node, StackContext context) {
   if (node->children == NULL)
     return 0;
 
-  char elseLabel[64], endLabel[64];
+  char elseLabel[LABEL_BUFFER_SIZE], endLabel[LABEL_BUFFER_SIZE];
   generateLabel(context, ASM_LABEL_PREFIX_ELSE, elseLabel, sizeof(elseLabel));
   generateLabel(context, ASM_LABEL_PREFIX_END_IF, endLabel, sizeof(endLabel));
 
@@ -404,7 +405,7 @@ int generateLoop(ASTNode node, StackContext context) {
   if (node->children == NULL || node->children->brothers == NULL)
     return 0;
 
-  char loopLabel[64], endLabel[64];
+  char loopLabel[LABEL_BUFFER_SIZE], endLabel[LABEL_BUFFER_SIZE];
   generateLabel(context, ASM_LABEL_PREFIX_LOOP, loopLabel, sizeof(loopLabel));
   generateLabel(context, ASM_LABEL_PREFIX_END_LOOP, endLabel, sizeof(endLabel));
 

--- a/src/codeGeneration/codeGenOperations.c
+++ b/src/codeGeneration/codeGenOperations.c
@@ -4,6 +4,7 @@
 
 #include <string.h>
 #include "registerHandling.h"
+#include "constants.h"
 
 /**
  * @brief Generates binary operations with type-aware instruction selection and
@@ -243,7 +244,7 @@ void generateUnaryOp(StackContext context, NodeTypes opType,
   const char *result = getRegisterName(resultReg, operandType);
 
   if (operandReg != resultReg) {
-    fprintf(context->file, ASM_TEMPLATE_MOVQ_REG_REG, operand, result);
+    fprintf(context->file, "    movq %s, %s\n", operand, result);
   }
 
   switch (opType) {
@@ -363,7 +364,7 @@ void generateFloatUnaryOp(StackContext context, NodeTypes opType,
 
   switch (opType) {
   case UNARY_MINUS_OP: {
-    char negLabel[64];
+    char negLabel[TEMP_LABEL_BUFFER_SIZE];
     snprintf(negLabel, sizeof(negLabel), "%s%d", ASM_LABEL_PREFIX_FLOAT_NEG,
              context->tempCount++);
 

--- a/src/codeGeneration/codeGeneration.c
+++ b/src/codeGeneration/codeGeneration.c
@@ -28,6 +28,7 @@
 #include "codeGenOperations.h"
 #include "errorHandling.h"
 #include "registerHandling.h"
+#include "constants.h"
 
 /**
  * @brief Generates assembly code for a single AST node and its subtree.
@@ -161,9 +162,11 @@ int generateNodeCode(ASTNode node, StackContext context) {
         RegisterId rightReg;
         if (field->type == TYPE_FLOAT) {
           rightReg = generateExpressionToRegister(rightNode, context, REG_XMM0);
+          char * tempText = extractText(fieldNode->start, fieldNode->length);
           fprintf(context->file,
                   ASM_TEMPLATE_MOVSS_REG_MEM,
-                  getFloatRegisterName(rightReg), memberOffset);
+                  getFloatRegisterName(rightReg), memberOffset, tempText);
+          free(tempText);
         }  else {
           rightReg = generateExpressionToRegister(rightNode, context, REG_RAX);
           const char *regName = getRegisterNameForSize(rightReg, field->type);
@@ -315,7 +318,7 @@ int generateNodeCode(ASTNode node, StackContext context) {
       free(tempVal);
     fprintf(context->file, "    pushq %%rbp\n");
     fprintf(context->file, "    movq %%rsp, %%rbp\n");
-    fprintf(context->file, "    subq $16, %%rsp\n");
+    fprintf(context->file, "    subq $%d, %%rsp\n", INITIAL_STACK_FRAME_SIZE);
 
     // Get nodes
     ASTNode paramList = node->children;

--- a/src/codeGeneration/codeGeneration.h
+++ b/src/codeGeneration/codeGeneration.h
@@ -6,11 +6,6 @@
 #include "symbolTable.h"
 #include <stdio.h>
 
-typedef enum {
-  TEMP_VAR_A = 8,
-  TEMP_VAR_B = 16,
-} tempVarOffset;
-
 /**
  * @brief String literal entry in the global string table.
  *
@@ -143,9 +138,9 @@ void generateStoreVariable(StackContext context, const char *start, size_t len,
 StructType findGlobalStructType(StackContext context, const char * start, size_t len);
 
 // Register management
-void spillRegisterToTempVar(StackContext context, RegisterId reg, DataType type, tempVarOffset tempVarOffset);
+void spillRegisterToTempVar(StackContext context, RegisterId reg, DataType type, int tempVarOffset);
 void restoreRegisterFromTempVar(StackContext context, RegisterId reg,
-                              DataType type, tempVarOffset tempVarOffset);
+                              DataType type, int tempVarOffset);
 RegisterId getOppositeBranchRegister(RegisterId reg);
 
 // Immediate value loading

--- a/src/codeGeneration/constants.h
+++ b/src/codeGeneration/constants.h
@@ -1,0 +1,77 @@
+/**
+ * @file constants.h
+ * @brief Centralized constants for code generation
+ */
+
+#ifndef CONSTANTS_H
+#define CONSTANTS_H
+
+// ========== STACK LAYOUT ==========
+
+/** Stack offset for first temporary variable (-8(%rbp)) */
+#define TEMP_VAR_A_OFFSET 8
+
+/** Stack offset for second temporary variable (-16(%rbp)) */
+#define TEMP_VAR_B_OFFSET 16
+
+/** Initial stack frame allocation for temp variables */
+#define INITIAL_STACK_FRAME_SIZE 16
+
+// ========== LABEL BUFFER SIZES ==========
+
+/** Max length for assembly labels: ".L<prefix>_<number>" */
+#define LABEL_BUFFER_SIZE 32
+
+/** Max length for string labels: ".STR_<number>" */
+#define STRING_LABEL_BUFFER_SIZE 32
+
+/** Max length for float/double labels: ".FLOAT_<number>" or ".DOUBLE_<number>" */
+#define FLOAT_LABEL_BUFFER_SIZE 32
+
+/** Max length for temporary inline labels */
+#define TEMP_LABEL_BUFFER_SIZE 64
+
+// ========== PARSER BUFFER SIZES ==========
+
+/** Buffer size for extracted AST node text */
+#define AST_TEXT_BUFFER_SIZE 256
+
+/** Maximum nesting depth for parsing */
+#define MAX_PARSE_DEPTH 256
+
+// ========== REGISTER LIMITS ==========
+
+/** Max general-purpose registers: RAX, RBX, RCX, RDX, RSI, RDI, R8-R11 */
+#define MAX_GP_REGISTERS 10
+
+/** Max XMM registers for floats: XMM0-XMM5 */
+#define MAX_XMM_REGISTERS 6
+
+/** Max function parameters in registers (x86-64 System V ABI) */
+#define MAX_REGISTER_PARAMS 6
+
+// ========== ALIGNMENT ==========
+
+/** Standard stack alignment for x86-64 */
+#define STACK_ALIGNMENT 16
+
+/** Minimum alignment for any data type */
+#define MIN_ALIGNMENT 8
+
+// ========== ERROR HANDLING ==========
+
+/** Max length for error code strings: "E<4-digit>" */
+#define ERROR_CODE_BUFFER_SIZE 8
+
+/** Max extracted source line length for errors */
+#define ERROR_SOURCE_LINE_MAX 512
+
+// ========== SYMBOL TABLE ==========
+
+/** Initial capacity for symbol table */
+#define SYMBOL_TABLE_INITIAL_SIZE 256
+
+/** Maximum identifier/symbol name length */
+#define MAX_SYMBOL_NAME_LENGTH 256
+
+#endif // CONSTANTS_H

--- a/src/codeGeneration/helpers.c
+++ b/src/codeGeneration/helpers.c
@@ -284,9 +284,9 @@ FloatDoubleEntry addFloatDoubleLiterals(StackContext context, const char *value,
         return NULL;
     }
     if (type == TYPE_FLOAT) {
-        snprintf(entry->label, 32, "%s%d", ASM_LABEL_PREFIX_FLOAT, entry->index);
+        snprintf(entry->label, FLOAT_LABEL_BUFFER_SIZE, "%s%d", ASM_LABEL_PREFIX_FLOAT, entry->index);
     } else {
-        snprintf(entry->label, 32, "%s%d", ASM_LABEL_PREFIX_DOUBLE, entry->index);
+        snprintf(entry->label, LABEL_BUFFER_SIZE, "%s%d", ASM_LABEL_PREFIX_DOUBLE, entry->index);
     }
 
     entry->next = context->floatDoubleEntries;

--- a/src/codeGeneration/stringHandling.c
+++ b/src/codeGeneration/stringHandling.c
@@ -8,6 +8,7 @@
 #include "asmTemplate.h"
 #include "codeGeneration.h"
 #include "errorHandling.h"
+#include "constants.h"
 
 /**
  * @brief Adds a string literal to the string table with automatic deduplication.
@@ -53,11 +54,22 @@ StringEntry addStringLiteral(StackContext context, const char *value) {
     }
 
     entry->value = strdup(value);
+    if(!entry->value){
+        repError(ERROR_MEMORY_ALLOCATION_FAILED, "Failed to duplicate string");
+        free(entry);
+        return NULL;
+    }
     entry->index = context->stringCount++;
 
     // Create label
-    entry->label = malloc(32);
-    snprintf(entry->label, 32, "%s%d", ASM_LABEL_PREFIX_STR, entry->index);
+    entry->label = malloc(STRING_LABEL_BUFFER_SIZE);
+    if(!entry->label){
+        repError(ERROR_MEMORY_ALLOCATION_FAILED, "Failed to allocate string label");
+        free(entry->value);  
+        free(entry);      
+        return NULL;
+    }
+    snprintf(entry->label, STRING_LABEL_BUFFER_SIZE, "%s%d", ASM_LABEL_PREFIX_STR, entry->index);
 
     entry->next = context->string;
     context->string = entry;

--- a/src/errorHandling/errorHandling.c
+++ b/src/errorHandling/errorHandling.c
@@ -24,12 +24,6 @@ void repError(ErrorCode code, const char *extraContext) {
 	reportError(code, NULL, extraContext);
 }
 
-char * formatErrorCode(ErrorCode err) {
-	static char buffer[8];
-	snprintf(buffer, sizeof(buffer), "E%04d", err);
-	return buffer;
-}
-
 const ErrorInfo * getErrorInfo(ErrorCode err) {
 	for (int i = 0; errorDatabase[i].code != ERROR_OK || i == 0; i++) {
 		if (errorDatabase[i].code == err) {
@@ -59,7 +53,9 @@ void printSourceSnippet (ErrorContext * context) {
 
 void reportError(ErrorCode code, ErrorContext *context, const char *extraContext) {
     const ErrorInfo *info = getErrorInfo(code);
-    const char *levelColor, *levelText;
+    // def vals
+    const char *levelColor = RED;
+    const char *levelText = "error";
 
     // Determine colors and text based on error level
     switch (info->level) {
@@ -83,10 +79,10 @@ void reportError(ErrorCode code, ErrorContext *context, const char *extraContext
     const char *RESET_COLOR = RESET ;
     const char *BLUE_COLOR = BLUE;
 
-    // Print main error line: error[E1002]: mismatched types
-    printf("%s%s %s[%s]:%s %s%s",
+    // Print main error line example: error[E1002]: mismatched types
+    printf("%s%s %s[E%04d]:%s %s%s",
            levelColor, levelText, RED,
-           formatErrorCode(code),
+           code,
            RESET_COLOR,
            YELLOW, info->message);
 

--- a/src/errorHandling/errorHandling.h
+++ b/src/errorHandling/errorHandling.h
@@ -150,7 +150,7 @@ typedef struct ErrorContext {
 	const char* file;
 	size_t line;
 	size_t column;
-	const char* source;
+	char* source;
 	size_t length;
 	size_t startColumn;
 } ErrorContext;
@@ -168,7 +168,6 @@ extern const ErrorInfo errorDatabase[];
 extern const size_t errorDatabaseCount;
 
 const ErrorInfo *getErrorInfo(ErrorCode code);
-char *formatErrorCode(ErrorCode code);
 void reportError(ErrorCode code, ErrorContext *context, const char *extraContext);
 void printErrorSummary(void);
 void printSourceSnippet(ErrorContext *context);

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -24,6 +24,7 @@
 
 #include "../errorHandling/errorHandling.h"
 #include "../lexer/lexer.h"
+#include "../codeGeneration/constants.h"
 
 #include <string.h>
 
@@ -149,7 +150,7 @@ ASTNode parseUnary(TokenList * list, size_t *pos) {
 		ADVANCE_TOKEN(list, pos);
 
 		ASTNode operand, opNode;
-		PARSE_OR_CLEANUP(operand,parseUnary(list, pos));
+		PARSE_OR_FAIL(operand,parseUnary(list, pos));
 
 		NodeTypes opType = getUnaryOpType(opToken->type);
 		if (opType == null_NODE) return NULL;
@@ -354,9 +355,9 @@ ASTNode parseLoop(TokenList* list, size_t* pos) {
 	ADVANCE_TOKEN(list, pos);
 
 	ASTNode condition, loopBody, loopNode;
-	PARSE_OR_CLEANUP(condition, parseExpression(list, pos, PREC_NONE));
+	PARSE_OR_FAIL(condition, parseExpression(list, pos, PREC_NONE));
 	EXPECT_TOKEN(list, pos, TK_LBRACE, ERROR_EXPECTED_OPENING_BRACE, "Expected '{' after loop condition");
-	PARSE_OR_CLEANUP(loopBody, parseBlock(list, pos));
+	PARSE_OR_FAIL(loopBody, parseBlock(list, pos));
 	CREATE_NODE_OR_FAIL(loopNode, loopToken, LOOP_STATEMENT, list, pos);
 
 	loopNode->children = condition;
@@ -658,7 +659,7 @@ ASTNode parseDeclaration(TokenList* list, size_t* pos, NodeTypes decType) {
  */
 ASTNode parseExpressionStatement(TokenList* list, size_t* pos) {
 	ASTNode expressionNode;
-	PARSE_OR_CLEANUP(expressionNode, parseExpression(list, pos, PREC_NONE));
+	PARSE_OR_FAIL(expressionNode, parseExpression(list, pos, PREC_NONE));
 	EXPECT_AND_ADVANCE(list, pos, TK_SEMI,ERROR_EXPECTED_SEMICOLON, "Expected ';'");
 	return expressionNode;
 }
@@ -800,7 +801,7 @@ void printASTTree(ASTNode node, char* prefix, int isLast) {
 	}
 	printf("\n");
 
-	char newPrefix[256];
+	char newPrefix[AST_TEXT_BUFFER_SIZE];
 	sprintf(newPrefix, "%s%s", prefix, isLast ? "    " : "|   ");
 
 	ASTNode child = node->children;

--- a/src/parser/parser.h
+++ b/src/parser/parser.h
@@ -45,9 +45,18 @@ const char *getCurrentTokenName(TokenList *list, size_t pos);
         var = (parseExpr); \
         if (!var) { \
             ASTNode _cleanup_nodes[] = {__VA_ARGS__}; \
-            for (size_t _i = 0; _i < sizeof(_cleanup_nodes)/sizeof(_cleanup_nodes[0]); _i++) { \
+            size_t _count = sizeof(_cleanup_nodes)/sizeof(_cleanup_nodes[0]); \
+            for (size_t _i = 0; _i < _count; _i++) { \
                 if (_cleanup_nodes[_i]) freeAST(_cleanup_nodes[_i]); \
             } \
+            return NULL; \
+        } \
+    } while(0)
+
+    #define PARSE_OR_FAIL(var, parseExpr) \
+    do { \
+        var = (parseExpr); \
+        if (!var) { \
             return NULL; \
         } \
     } while(0)

--- a/src/parser/parserHelpers.c
+++ b/src/parser/parserHelpers.c
@@ -43,7 +43,7 @@ NodeTypes getDecType(TokenType type) {
     return null_NODE;
 }
 
-static int containsFChar(const char * val, int i, int hasDot, size_t len){
+static int containsFChar(const char * val, size_t i, int hasDot, size_t len){
 	return (val[i] == 'f' || val[i] == 'F') && i == len - 1 && hasDot;
 }
 

--- a/src/semantic/typeChecker.c
+++ b/src/semantic/typeChecker.c
@@ -236,7 +236,7 @@ DataType getExpressionType(ASTNode node, TypeCheckContext context) {
         case VARIABLE: {
             Symbol symbol = lookupSymbol(context->current, node->start, node->length);
             if (symbol == NULL) {
-                const char * tempText = extractText(node->start, node->length);
+                char * tempText = extractText(node->start, node->length);
                 REPORT_ERROR(ERROR_INVALID_EXPRESSION, node, context, tempText);
                 free(tempText);
                 return TYPE_UNKNOWN;


### PR DESCRIPTION
# 🔧 Technical Debt Fixed

## ✅ Changes

1. **Memory Leaks**: Added cleanup cascade in `stringHandling.c` and `helpers.c` (5 leaks → 0)
2. **Thread-Safety**: Removed static buffer in `formatErrorCode()`
3. **Magic Numbers**: Created `constants.h` with documented constants
4. **Warnings**: Split `PARSE_OR_CLEANUP` macro, fixed type mismatches (8 warnings → 0)